### PR TITLE
remove danger parameter -i, --ignore_dependencies

### DIFF
--- a/plugins/backfill/main.py
+++ b/plugins/backfill/main.py
@@ -87,7 +87,7 @@ class Backfill(get_baseview()):
         if clear == 'true':
             cmd = ['airflow', 'clear', '-c', str(dag_name), '-s', str(start_date), '-e', str(end_date)]
         else:
-            cmd = ['airflow', 'backfill', str(dag_name), '-s', str(start_date), '-e', str(end_date), '-i']
+            cmd = ['airflow', 'backfill', str(dag_name), '-s', str(start_date), '-e', str(end_date)]
 
         print('BACKFILL CMD:', cmd)
 
@@ -126,7 +126,7 @@ class Backfill(get_baseview()):
             # Prepare the command and execute in background
             background_cmd = f"screen -dmS {screen_id} airflow clear -c {dag_name} -s {start_date} -e {end_date}"
         else:
-            background_cmd = f"screen -dmS {screen_id} airflow backfill {dag_name} -s {start_date} -e {end_date} -i"
+            background_cmd = f"screen -dmS {screen_id} airflow backfill {dag_name} -s {start_date} -e {end_date}"
 
         # Update command in file
         file_ops('w', background_cmd)


### PR DESCRIPTION
The backfill tasks starting with parameter (acording to documents):
-i, --ignore_dependencies
Skip upstream tasks, run only the tasks matching the regexp. Only works in conjunction with task_regex

But in tested version (1.10.10) this param not check task_regex. In this case all tasks runs skiping upstreaming. Not good behavor for default.

PR fix this: remove -i param.